### PR TITLE
Proposal: Add 'mxb' and 'mxt' space props

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,22 +18,24 @@ The space utility converts shorthand margin and padding props to margin and padd
 
 Margin and padding props follow a shorthand syntax for specifying direction.
 
-| Prop                  | CSS Property                   |
-| --------------------- | ------------------------------ |
-| `margin`, `m`         | margin                         |
-| `marginTop`, `mt`     | margin-top                     |
-| `marginRight`, `mr`   | margin-right                   |
-| `marginBottom`, `mb`  | margin-bottom                  |
-| `marginLeft`, `ml`    | margin-left                    |
-| `marginX`, `mx`       | margin-left and margin-right   |
-| `marginY`, `my`       | margin-top and margin-bottom   |
-| `padding`, `p`        | padding                        |
-| `paddingTop`, `pt`    | padding-top                    |
-| `paddingRight`, `pr`  | padding-right                  |
-| `paddingBottom`, `pb` | padding-bottom                 |
-| `paddingLeft`, `pl`   | padding-left                   |
-| `paddingX`, `px`      | padding-left and padding-right |
-| `paddingY`, `py`      | padding-top and padding-bottom |
+| Prop                   | CSS Property                   |
+| ---------------------- | ------------------------------ |
+| `margin`, `m`          | margin                         |
+| `marginTop`, `mt`      | margin-top                     |
+| `marginRight`, `mr`    | margin-right                   |
+| `marginBottom`, `mb`   | margin-bottom                  |
+| `marginLeft`, `ml`     | margin-left                    |
+| `marginX`, `mx`        | margin-left and margin-right   |
+| `marginY`, `my`        | margin-top and margin-bottom   |
+| `marginXBottom`, `mxb` | marginX and margin-bottom      |
+| `marginXTop`, `mxt`    | marginX and margin-top         |
+| `padding`, `p`         | padding                        |
+| `paddingTop`, `pt`     | padding-top                    |
+| `paddingRight`, `pr`   | padding-right                  |
+| `paddingBottom`, `pb`  | padding-bottom                 |
+| `paddingLeft`, `pl`    | padding-left                   |
+| `paddingX`, `px`       | padding-left and padding-right |
+| `paddingY`, `py`       | padding-top and padding-bottom |
 
 ```jsx
 // examples (margin prop)
@@ -508,7 +510,7 @@ const Card = styled.div`
         boxShadow: 'large',
         borderRadius: 4,
       },
-    }
+    },
   })}
 `
 Card.defaultProps = {
@@ -519,7 +521,7 @@ Card.defaultProps = {
 
 ## Legacy Variants
 
-The legacy variants require styles to be defined in the theme object and do *not* use `@styled-system/css` for transformation.
+The legacy variants require styles to be defined in the theme object and do _not_ use `@styled-system/css` for transformation.
 
 ```js
 import { textStyle, colorStyle, buttonStyle } from 'styled-system'

--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -23,6 +23,8 @@ const aliases = {
   ml: 'marginLeft',
   mx: 'marginX',
   my: 'marginY',
+  mxb: 'marginXBottom',
+  mxt: 'marginXTop',
   p: 'padding',
   pt: 'paddingTop',
   pr: 'paddingRight',
@@ -35,6 +37,8 @@ const aliases = {
 const multiples = {
   marginX: ['marginLeft', 'marginRight'],
   marginY: ['marginTop', 'marginBottom'],
+  marginXBottom: ['marginLeft', 'marginRight', 'marginBottom'],
+  marginXTop: ['marginLeft', 'marginRight', 'marginBottom'],
   paddingX: ['paddingLeft', 'paddingRight'],
   paddingY: ['paddingTop', 'paddingBottom'],
   size: ['width', 'height'],
@@ -136,6 +140,8 @@ const transforms = [
   'marginLeft',
   'marginX',
   'marginY',
+  'marginXTop',
+  'marginXBottom',
   'top',
   'bottom',
   'left',
@@ -209,7 +215,7 @@ export const css = args => (props = {}) => {
 
     if (multiples[prop]) {
       const dirs = multiples[prop]
-      
+
       for (let i = 0; i < dirs.length; i++) {
         result[dirs[i]] = value
       }

--- a/packages/css/test/index.js
+++ b/packages/css/test/index.js
@@ -259,13 +259,13 @@ test('handles negative top, left, bottom, and right from scale', () => {
 
 test('skip breakpoints', () => {
   const result = css({
-    width: [ '100%', , '50%' ],
+    width: ['100%', , '50%'],
   })(theme)
   expect(result).toEqual({
     width: '100%',
     '@media screen and (min-width: 52em)': {
       width: '50%',
-    }
+    },
   })
 })
 
@@ -290,9 +290,9 @@ test('padding shorthand does not collide with nested p selector', () => {
 
 test('ignores array values longer than breakpoints', () => {
   const result = css({
-    width: [ 32, 64, 128, 256, 512 ]
+    width: [32, 64, 128, 256, 512],
   })({
-    breakpoints: [ '32em', '40em' ],
+    breakpoints: ['32em', '40em'],
   })
   expect(result).toEqual({
     width: 32,
@@ -403,6 +403,6 @@ test('returns outline color from theme', () => {
     outlineColor: 'primary',
   })(theme)
   expect(result).toEqual({
-    outlineColor: 'tomato'
+    outlineColor: 'tomato',
   })
 })

--- a/packages/space/src/index.js
+++ b/packages/space/src/index.js
@@ -64,6 +64,18 @@ configs.margin = {
     transform: getMargin,
     defaultScale: defaults.space,
   },
+  marginXBottom: {
+    properties: ['marginLeft', 'marginRight', 'marginBottom'],
+    scale: 'space',
+    transform: getMargin,
+    defaultScale: defaults.space,
+  },
+  marginXTop: {
+    properties: ['marginLeft', 'marginRight', 'marginTop'],
+    scale: 'space',
+    transform: getMargin,
+    defaultScale: defaults.space,
+  },
 }
 configs.margin.m = configs.margin.margin
 configs.margin.mt = configs.margin.marginTop
@@ -72,6 +84,8 @@ configs.margin.mb = configs.margin.marginBottom
 configs.margin.ml = configs.margin.marginLeft
 configs.margin.mx = configs.margin.marginX
 configs.margin.my = configs.margin.marginY
+configs.margin.mxb = configs.margin.marginXBottom
+configs.margin.mxt = configs.margin.marginXTop
 
 configs.padding = {
   padding: {
@@ -120,6 +134,9 @@ configs.padding.py = configs.padding.paddingY
 
 export const margin = system(configs.margin)
 export const padding = system(configs.padding)
-export const space = compose(margin, padding)
+export const space = compose(
+  margin,
+  padding
+)
 
 export default space

--- a/packages/space/test/index.js
+++ b/packages/space/test/index.js
@@ -132,6 +132,22 @@ test('my prop overrides mt prop', () => {
   expect(styles).toEqual({ marginTop: 8, marginBottom: 8 })
 })
 
+test('mxb prop overrides mb prop', () => {
+  const styles = space({
+    mb: 1,
+    mxb: 2,
+  })
+  expect(styles).toEqual({ marginLeft: 8, marginRight: 8, marginBottom: 8 })
+})
+
+test('mxt prop overrides mt prop', () => {
+  const styles = space({
+    mt: 1,
+    mxt: 2,
+  })
+  expect(styles).toEqual({ marginLeft: 8, marginRight: 8, marginTop: 8 })
+})
+
 test('margin overrides m prop', () => {
   const styles = space({
     m: 1,
@@ -191,7 +207,7 @@ test('supports object values', () => {
       _: 0,
       0: 1,
       1: 2,
-    }
+    },
   })
   expect(styles).toEqual({
     margin: 0,
@@ -210,7 +226,7 @@ test('supports non-array breakpoints', () => {
     breakpoints: {
       small: '40em',
       medium: '52em',
-    }
+    },
   }
   const styles = space({
     theme,
@@ -221,7 +237,7 @@ test('supports non-array breakpoints', () => {
       _: 0,
       small: 1,
       medium: 2,
-    }
+    },
   })
   expect(styles).toEqual({
     margin: 0,


### PR DESCRIPTION
Hi there!

I'm not entirely expecting this to be merged, more of a "what do you think?" PR!

Introduces `mxb` and `mxt` space props to style margins. 

A common pattern I've seen used is the aspiration to _only_ use either `margin-top` or `margin-bottom` when spacing elements vertically.

At the moment that's a lot of:

```jsx
<Box m={2} mt={0} /> || <Box mx={2} mb={2} />
```

Which isn't that bad, but with `mxb` I can do:

```jsx
<Box mxb={2} />
```

to produce:

```css
.foo {
  margin-left: 8;
  margin-right: 8;
  margin-bottom: 8;
}
```

I very rarely need `mb` to be a different level of the scale to the `mx` value, but I suppose if people need a different level of the theme scale:

```jsx
<Box mx={2} mb={3} />
```

...then this would be kind of pointless.

Perhaps an over-optimization, but I thought I'd share to see what you think.

Thanks for `styled-system`!